### PR TITLE
Fix compatibility with Libertine font package

### DIFF
--- a/fvextra/fvextra.dtx
+++ b/fvextra/fvextra.dtx
@@ -2137,7 +2137,7 @@
 % Additional left indentation to make room for the left break symbol.
 %    \begin{macrocode}
 \newdimen\FV@BreakSymbolIndentLeft
-\settowidth{\FV@BreakSymbolIndentLeft}{\ttfamily xxxx}
+\AtBeginDocument{\settowidth{\FV@BreakSymbolIndentLeft}{\ttfamily xxxx}}
 \define@key{FV}{breaksymbolindentleft}{\FV@BreakSymbolIndentLeft=#1\relax}
 \define@key{FV}{breaksymbolindent}{\fvset{breaksymbolindentleft=#1}}
 %    \end{macrocode}
@@ -2147,7 +2147,7 @@
 % Additional right indentation to make room for the right break symbol.
 %    \begin{macrocode}
 \newdimen\FV@BreakSymbolIndentRight
-\settowidth{\FV@BreakSymbolIndentRight}{\ttfamily xxxx}
+\AtBeginDocument{\settowidth{\FV@BreakSymbolIndentRight}{\ttfamily xxxx}}
 \define@key{FV}{breaksymbolindentright}{\FV@BreakSymbolIndentRight=#1\relax}
 %    \end{macrocode}
 % \end{macro}

--- a/fvextra/fvextra.sty
+++ b/fvextra/fvextra.sty
@@ -559,11 +559,11 @@
 \define@key{FV}{breaksymbolsepright}{\FV@BreakSymbolSepRight=#1\relax}
 \fvset{breaksymbolsepright=1em}
 \newdimen\FV@BreakSymbolIndentLeft
-\settowidth{\FV@BreakSymbolIndentLeft}{\ttfamily xxxx}
+\AtBeginDocument{\settowidth{\FV@BreakSymbolIndentLeft}{\ttfamily xxxx}}
 \define@key{FV}{breaksymbolindentleft}{\FV@BreakSymbolIndentLeft=#1\relax}
 \define@key{FV}{breaksymbolindent}{\fvset{breaksymbolindentleft=#1}}
 \newdimen\FV@BreakSymbolIndentRight
-\settowidth{\FV@BreakSymbolIndentRight}{\ttfamily xxxx}
+\AtBeginDocument{\settowidth{\FV@BreakSymbolIndentRight}{\ttfamily xxxx}}
 \define@key{FV}{breaksymbolindentright}{\FV@BreakSymbolIndentRight=#1\relax}
 \newcommand{\FancyVerbBreakSymbolLeftLogic}[1]{%
   \ifnum\value{linenumber}=1\relax\else{#1}\fi}


### PR DESCRIPTION
Delay \settowidth (which depends font settings) using \AtBeginDocument.

Closes #4.