### PR TITLE
Fix samepage behavior (issue #32)

### DIFF
--- a/fvextra/fvextra.dtx
+++ b/fvextra/fvextra.dtx
@@ -26,7 +26,7 @@
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
 %<package>\ProvidesPackage{fvextra}
 %<*package>
-    [2026/02/25 v1.14.0 fvextra - extensions and patches for fancyvrb]
+    [2026/03/18 v1.14.1 fvextra - extensions and patches for fancyvrb]
 %</package>
 %
 %<*driver>

--- a/fvextra/fvextra.dtx
+++ b/fvextra/fvextra.dtx
@@ -8056,6 +8056,15 @@
      \FVExtraRetokenizeVArg{\FV@PYG@retoked{#1}}{\FancyVerbRestoreCodes}}{#2}}%
    {\FV@PYG@retoked{#1}{#2}}%
   \endgroup}%
+% Tentative fix of samepage behavior with lineno >= v5.9 (2026-03-08)
+\IfPackageAtLeastTF{lineno}{2026-03-08}{%
+  \def\FV@bgcoloroverlap{%
+    \ifx\FV@backgroundcolorboxoverlap\relax
+    \else
+      \nopagebreak  % <<< added
+      \vspace{-\FV@backgroundcolorboxoverlap}%
+  \fi}
+}{}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/fvextra/fvextra.dtx
+++ b/fvextra/fvextra.dtx
@@ -8064,7 +8064,9 @@
       \nopagebreak  % <<< added
       \vspace{-\FV@backgroundcolorboxoverlap}%
   \fi}
-}{}
+}{\PackageWarning{fvextra}{samepage is disabled with lineno < v5.9, %
+    to avoid potential infinite loop}
+}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/fvextra/fvextra.sty
+++ b/fvextra/fvextra.sty
@@ -20,7 +20,7 @@
 %% 
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesPackage{fvextra}
-    [2026/02/25 v1.14.0 fvextra - extensions and patches for fancyvrb]
+    [2026/03/18 v1.14.1 fvextra - extensions and patches for fancyvrb]
 \RequirePackage{etoolbox}
 \RequirePackage{fancyvrb}
 \RequirePackage{upquote}

--- a/fvextra/fvextra.sty
+++ b/fvextra/fvextra.sty
@@ -3877,6 +3877,14 @@
      \FVExtraRetokenizeVArg{\FV@PYG@retoked{#1}}{\FancyVerbRestoreCodes}}{#2}}%
    {\FV@PYG@retoked{#1}{#2}}%
   \endgroup}%
+\IfPackageAtLeastTF{lineno}{2026-03-08}{%
+  \def\FV@bgcoloroverlap{%
+    \ifx\FV@backgroundcolorboxoverlap\relax
+    \else
+      \nopagebreak  % <<< added
+      \vspace{-\FV@backgroundcolorboxoverlap}%
+  \fi}
+}{}
 %% \Finale
 \endinput
 %%

--- a/fvextra/fvextra.sty
+++ b/fvextra/fvextra.sty
@@ -3884,7 +3884,9 @@
       \nopagebreak  % <<< added
       \vspace{-\FV@backgroundcolorboxoverlap}%
   \fi}
-}{}
+}{\PackageWarning{fvextra}{samepage is disabled with lineno < v5.9, %
+    to avoid potential infinite loop}
+}
 %% \Finale
 \endinput
 %%


### PR DESCRIPTION
Apply tentative patch provided by @muzimuzhi only if loaded lineno is v5.9 or later.

This is intended as a POC.
I'm providing it in the hope of seeing some progress at https://github.com/gpoore/fvextra/issues/32.

TBH, I'm not an expert on coding LaTeX packages and Just hoping this helps.